### PR TITLE
Have documentation such that jade-mode is used for .jade files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Add the following lines to any of your initialization files
     (require 'sws-mode)
     (require 'jade-mode)    
     (add-to-list 'auto-mode-alist '("\\.styl$" . sws-mode))
-    (add-to-list 'auto-mode-alist '("\\.jade$" . sws-mode))
+    (add-to-list 'auto-mode-alist '("\\.jade$" . jade-mode))


### PR DESCRIPTION
Hello Brian,

I believe you made a minor mistake in your documentation, otherwise won't
people want to automatically want to associate jade-mode with .jade files
rather than simply sws-mode?

Keep up the good work, 

—Travis Jeffery
