### PR TITLE
Add package dependencies for ELPA support

### DIFF
--- a/jade-mode.el
+++ b/jade-mode.el
@@ -1,9 +1,12 @@
-;;; jade-mode.el --- emacs major mode for editing .jade files
+;;; jade-mode.el --- Major mode for editing .jade files
+;;;
 ;;; URL: https://github.com/brianc/jade-mode
 ;;; Author: Brian M. Carlson and other contributors
+;;; Package-Requires: ((sws-mode "0"))
+;;;
 ;;; copied from http://xahlee.org/emacs/elisp_syntax_coloring.html
-;;; jade-mode.el ends here
 (require 'font-lock)
+(require 'sws-mode)
 
 (defun jade-debug (string &rest args)
   "Prints a debug message"
@@ -44,6 +47,7 @@
 ;;(define-key jade-mode-map [S-tab] 'jade-unindent-line)
 
 ;; mode declaration
+;;;###autoload
 (define-derived-mode jade-mode sws-mode
   "Jade"
   "Major mode for editing jade node.js templates"
@@ -68,6 +72,9 @@
   ;; highlight syntax
   (setq font-lock-defaults '(jade-font-lock-keywords)))
 
-(provide 'jade-mode)
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jade$" . jade-mode))
+
+(provide 'jade-mode)
+;;; jade-mode.el ends here

--- a/stylus-mode.el
+++ b/stylus-mode.el
@@ -1,9 +1,12 @@
-;;; stylus-mode.el --- emacs major mode for editing .jade files
+;;; stylus-mode.el --- Major mode for editing .jade files
+;;;
 ;;; URL: https://github.com/brianc/jade-mode
 ;;; Author: Brian M. Carlson and other contributors
+;;; Package-Requires: ((sws-mode "0"))
+;;;
 ;;; copied from http://xahlee.org/emacs/elisp_syntax_coloring.html
-;;; stylus-mode.el ends here
 (require 'font-lock)
+(require 'sws-mode)
 
 (defun stylus-debug (string &rest args)
   "Prints a debug message"
@@ -65,6 +68,7 @@
 ;;(define-key stylus-mode-map [S-tab] 'stylus-unindent-line)
 
 ;; mode declaration
+;;;###autoload
 (define-derived-mode stylus-mode sws-mode
   "Stylus"
   "Major mode for editing stylus node.js templates"
@@ -89,6 +93,8 @@
   ;; highlight syntax
   (setq font-lock-defaults '(stylus-font-lock-keywords)))
 
-(provide 'stylus-mode)
-
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.styl$" . stylus-mode))
+
+(provide 'stylus-mode)
+;;; stylus-mode.el ends here

--- a/sws-mode.el
+++ b/sws-mode.el
@@ -1,7 +1,8 @@
 ;;; sws-mode.el --- (S)ignificant (W)hite(S)pace mode
+;;;
 ;;; URL: https://github.com/brianc/jade-mode
 ;;; Author: Brian M. Carlson and other contributors
-;;; sws-mode.el ends here
+;;;
 (require 'font-lock)
 
 (defvar sws-tab-width 2)
@@ -114,6 +115,7 @@
 (define-key sws-mode-map [S-tab] 'sws-dendent-line)
 (define-key sws-mode-map [backtab] 'sws-dendent-line)
 
+;;;###autoload
 (define-derived-mode sws-mode fundamental-mode
   "sws"
   "Major mode for editing significant whitespace files"
@@ -135,3 +137,4 @@
   (setq major-mode 'sws-mode))
 
 (provide 'sws-mode)
+;;; sws-mode.el ends here


### PR DESCRIPTION
Okay, so the packages are up on Melpa, and I thought I'd send a quick pull request which adds proper dependency specs -- this means when ELPA users install jade-mode or stylus-mode, they'll automatically get sws-mode installed too.

Additionally, I've added magic ";;;###autoload" comments in a couple of places, so that people usually won't need to explicitly "require" jade-mode before using it.

Have a great day!

-Steve
