### PR TITLE
Add comment syntax to allow for M-x (un)comment-region.

### DIFF
--- a/jade-mode.el
+++ b/jade-mode.el
@@ -86,6 +86,9 @@ For detail, see `comment-dwim'."
   (setq mode-name "Jade")
   (setq major-mode 'jade-mode)
 
+  ;; comment syntax
+  (set (make-local-variable 'comment-start) "// ")
+
   ;; default tab width
   (setq sws-tab-width 2)
   (make-local-variable 'indent-line-function)


### PR DESCRIPTION
Hey!

I've added the 'comment-start local var in order to use M-x (un)comment-region while in jade mode.
