### PR TITLE
Backtabbing highlighted text hangs emacs (Jade-mode)

### DIFF
--- a/sws-mode.el
+++ b/sws-mode.el
@@ -82,17 +82,19 @@
 (defun sws-move-region (begin end prog)
   "Moves left is dir is null, otherwise right. prog is '+ or '-"
   (save-excursion
-    (let (first-indent indent-diff)
+    (let ((first-indent indent-diff)
+	  (num-lines-indented (count-lines-region begin end))
+	  )
       (goto-char begin)
       (setq first-indent (current-indentation))
       (sws-indent-to
        (funcall prog first-indent sws-tab-width))
       (setq indent-diff (- (current-indentation) first-indent))
+      (forward-line 1)
       ;; move other lines based on movement of first line
-      (while (< (point) end)
-        (forward-line 1)
-        (if (< (point) end)
-            (sws-indent-to (+ (current-indentation) indent-diff)))))))
+      (dotimes (i (- num-lines-indented 1))
+	(sws-indent-to (+ (current-indentation) indent-diff))
+	(forward-line 1)))))
 
 (defun sws-indent-region (begin end)
   "Indents the selected region"


### PR DESCRIPTION
@brianc 
#27 
Uses the number of lines in a region instead of the location of point relative to the end of the original region to determine how many lines to indent.