### PR TITLE
Closes #26. Fix inline '//' highlight as comment

### DIFF
--- a/example.jade
+++ b/example.jade
@@ -10,6 +10,8 @@ html(lang="en")
         ul#nav_list something sweet
           li
       #content
+        // here is a real comment
+        a(href = 'http://www.google.com') http://www.google.com
         - if (youAreUsingJade)
           p You are amazing
         - else
@@ -18,10 +20,4 @@ html(lang="en")
             input(type: "text", name='user[name]', readonly: true, disabled)
       #footer
         #copywrite-text= locals
-        
-        
 
-        
-
-        
-        

--- a/jade-mode.el
+++ b/jade-mode.el
@@ -50,13 +50,12 @@ For detail, see `comment-dwim'."
     (,"#\\(\\w\\|_\\|-\\)*" . font-lock-variable-name-face) ;; id
     (,"\\(?:^[ {2,}]*\\(?:[a-z0-9_:\\-]*\\)\\)?\\(#[A-Za-z0-9\-\_]*[^ ]\\)" 1 font-lock-variable-name-face) ;; id
     (,"\\(?:^[ {2,}]*\\(?:[a-z0-9_:\\-]*\\)\\)?\\(\\.[A-Za-z0-9\-\_]*\\)" 1 font-lock-type-face) ;; class name
-    (,"^[ {2,}]*[a-z0-9_:\\-]*" 0 font-lock-function-name-face))) ;; tag name
+    (,"^[ {2,}]*[a-z0-9_:\\-]*" 0 font-lock-function-name-face) ;; tag name
+    (,"^\\s-*//.*" 0 font-lock-comment-face t))) ;; jade block comments
 
 ;; syntax table
 (defvar jade-syntax-table
   (let ((syn-table (make-syntax-table)))
-    (modify-syntax-entry ?\/ ". 12b" syn-table)
-    (modify-syntax-entry ?\n "> b" syn-table)
     (modify-syntax-entry ?' "\"" syn-table)
     syn-table)
   "Syntax table for `jade-mode'.")
@@ -89,6 +88,7 @@ For detail, see `comment-dwim'."
 
   ;; comment syntax
   (set (make-local-variable 'comment-start) "// ")
+  (set (make-local-variable 'comment-start-skip) "//\\s-*")
 
   ;; default tab width
   (setq sws-tab-width 2)


### PR DESCRIPTION
    Remove comment-related modification to syntax table, use simple
    search-based fontification to highlight comments instead. Add
    local variable `comment-start-skip' to maintain correct
    comment-dwim functionality.