### PR TITLE
fix unbound variable reference in let binding

### DIFF
--- a/sws-mode.el
+++ b/sws-mode.el
@@ -82,7 +82,7 @@
 (defun sws-move-region (begin end prog)
   "Moves left is dir is null, otherwise right. prog is '+ or '-"
   (save-excursion
-    (let ((first-indent indent-diff)
+    (let (first-indent indent-diff
 	  (num-lines-indented (count-lines-region begin end))
 	  )
       (goto-char begin)


### PR DESCRIPTION
In 40efeb499a8, the let binding in (sws-move-region) was changed such
that the `first-indent` variable is bound to the value of the
`indent-diff` variable, rather than just creating two empty bindings for
two separate variables.  Since the `indent-diff` variable doesn't exist
we take a void variable exception:

    Debugger entered--Lisp error: (void-variable indent-diff)
      (let ((first-indent indent-diff) (num-lines-indented (count-lines-region begin end))) (goto-char begin) (setq first-indent (current-indentation)) (sws-indent-to (funcall prog first-indent sws-tab-width)) (setq indent-diff (- (current-indentation) first-indent)) (forward-line 1) (let ((--dotimes-limit-- (- num-lines-indented 1)) (i 0)) (while (< i --dotimes-limit--) (sws-indent-to (+ (current-indentation) indent-diff)) (forward-line 1) (setq i (1+ i)))))
      (save-excursion (let ((first-indent indent-diff) (num-lines-indented (count-lines-region begin end))) (goto-char begin) (setq first-indent (current-indentation)) (sws-indent-to (funcall prog first-indent sws-tab-width)) (setq indent-diff (- (current-indentation) first-indent)) (forward-line 1) (let ((--dotimes-limit-- (- num-lines-indented 1)) (i 0)) (while (< i --dotimes-limit--) (sws-indent-to (+ (current-indentation) indent-diff)) (forward-line 1) (setq i (1+ i))))))
      sws-move-region(1 55 +)
      sws-indent-region(1 55)
      indent-region(1 55 nil)
      call-interactively(indent-region nil nil)
      command-execute(indent-region)

Fix this by going back to binding `indent-diff` to a new variable.