### PR TITLE
[#37] Highlight string lit. manually - Closes #37

### DIFF
--- a/example.jade
+++ b/example.jade
@@ -19,10 +19,11 @@ html(lang="en")
         - else
           p Get on it!
           form
-            input(type: "text", name='user[name]', readonly: true, disabled)
+            input(type = "text", name='user[name]', readonly = true, disabled)
         div#single-quote.example
           = 'this single quote should highlight as a string'
           = 'this one' + "and this should too"
+          span= 'another' + "quote example"
           span this one shouldn't higlight strings or... .other #things if else
           | this one shouldn't highlight strings, and the same goes for .keywords #ok ?
         div#paren.content.example(style = 'float-left') Content .here #should be plain if for

--- a/jade-mode.el
+++ b/jade-mode.el
@@ -77,15 +77,9 @@
 
 (defvar jade-font-lock-keywords
   `(
-    ;; higlight string literals on lines beginning with an equals sign
-    ;; TODO improve this to play nice with attribute assignments in
-    ;; parentheses following tags
-    (,(concat "^\\s-*"
-              "=")
-              (,(concat jade-single-quote-string-re "\\|" jade-double-quote-string-re)
-               nil
-               nil
-               (0 font-lock-string-face)))
+    ;; highlight string literals everywhere (except where we later
+    ;; remove all font lock faces)
+    (,(concat jade-single-quote-string-re "\\|" jade-double-quote-string-re) . font-lock-string-face)
 
     (,"!!!\\|doctype\\( ?[A-Za-z0-9\-\_]*\\)?" 0 font-lock-comment-face) ;; doctype
     (,jade-keywords . font-lock-keyword-face) ;; keywords
@@ -298,8 +292,8 @@ Follows indentation behavior of `indent-rigidly'."
   (define-key jade-mode-map [backtab] 'jade-unindent)
   (define-key jade-mode-map (kbd "RET") 'jade-newline-and-indent)
 
-  ;; highlight syntax
-  (setq font-lock-defaults '(jade-font-lock-keywords)))
+  ;; highlight keywords, ignore syntactic font-lock
+  (setq font-lock-defaults '(jade-font-lock-keywords t)))
 
 
 ;;;###autoload


### PR DESCRIPTION
    - Turn off syntactic font-lock and simply highlight string literals
      with their own font-lock-keywords rule
    - We lose the highlighting of the in-progress string literals, but
      the benefits outweigh that issue for now, IMO