### PR TITLE
simpler fix for highlighting mixins issue #49

### DIFF
--- a/example.jade
+++ b/example.jade
@@ -25,6 +25,7 @@ html(lang="en", class = ['classOne', 'classTwo'].join(','))
           = 'this single quote should highlight as a string'
           = 'this one' + "and this should too"
           span= 'another' + "quote example"
+					+this_is_a_mixin("this is a parameter")
           span this one shouldn't higlight strings or... .other #things if else
           | this one shouldn't highlight strings, and the same goes for .keywords #ok ?
         div#paren.content.example(style = 'float: left;') Content .here #should be plain if for

--- a/jade-mode.el
+++ b/jade-mode.el
@@ -78,7 +78,7 @@
 (defvar jade-single-quote-string-re "[']\\(\\\\.\\|[^'\n]\\)*[']"
   "Regexp used to match a single-quoted string literal")
 
-(defvar jade-tag-declaration-char-re "[-a-zA-Z0-9_.#]"
+(defvar jade-tag-declaration-char-re "[-a-zA-Z0-9_.#+]"
   "Regexp used to match a character in a tag declaration")
 
 (defvar jade-font-lock-keywords


### PR DESCRIPTION
adding a + sign to the jade-tag-declaration regex was enough to highlight mixins correctly as js, but see my othe pull request for improved tests 