### PR TITLE
Files with ".pug" extension are now detected (issue #65)

### DIFF
--- a/jade-mode.el
+++ b/jade-mode.el
@@ -393,6 +393,7 @@ region defined by BEG and END."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jade\\'" . jade-mode))
+(add-to-list 'auto-mode-alist '("\\.pug\\'" . jade-mode))
 
 (provide 'jade-mode)
 ;;; jade-mode.el ends here


### PR DESCRIPTION
The mode is now loaded on *.pug files. So, from now it supports the renaming of jade.