### PR TITLE
fix `.pug` extension to be auto-loaded

### DIFF
--- a/jade-mode.el
+++ b/jade-mode.el
@@ -393,6 +393,7 @@ region defined by BEG and END."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jade\\'" . jade-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pug\\'" . jade-mode))
 
 (provide 'jade-mode)


### PR DESCRIPTION
Hi. It seems like `.pug` extension does not get to `jade-mode-autoloads.el`.

The fix is pretty simple though.