### PR TITLE
Derive from text-mode, remove unneeded code

### DIFF
--- a/sws-mode.el
+++ b/sws-mode.el
@@ -122,10 +122,9 @@
 (define-key sws-mode-map [backtab] 'sws-dendent-line)
 
 ;;;###autoload
-(define-derived-mode sws-mode fundamental-mode
+(define-derived-mode sws-mode text-mode
   "sws"
   "Major mode for editing significant whitespace files"
-  (kill-all-local-variables)
 
   ;; default tab width
   (setq sws-tab-width 2)
@@ -136,11 +135,7 @@
   (setq indent-region-function 'sws-indent-region)
 
   ;; TODO needed?
-  (setq indent-tabs-mode nil)
-
-  ;; keymap
-  (use-local-map sws-mode-map)
-  (setq major-mode 'sws-mode))
+  (setq indent-tabs-mode nil))
 
 (provide 'sws-mode)
 ;;; sws-mode.el ends here


### PR DESCRIPTION
Both `jade-mode` and `stylus-mode` derive from `sws-mode` which is neither derived from `text-mode` nor `prog-mode`.  Pick either to allow people to run hooks for all textual/program modes.  While editing this code I also removed things done automatically by `define-derived-mode`.