### PR TITLE
Fix package headers

### DIFF
--- a/jade-mode.el
+++ b/jade-mode.el
@@ -1,8 +1,19 @@
-;;; jade-mode.el --- Major mode for editing .jade files
-;;;
-;;; URL: https://github.com/brianc/jade-mode
-;;; Author: Brian M. Carlson and other contributors
-;;; inspired by http://xahlee.org/emacs/elisp_syntax_coloring.html
+;;; jade-mode.el --- Major mode for editing .jade files  -*- lexical-binding: t -*-
+
+;; Copyright 2010-2021  Brian Carlson
+
+;; Author: Brian M. Carlson and other contributors
+;; Version: 1.0.1
+;; Keywords: languages
+;; URL: https://github.com/brianc/jade-mode
+
+;;; Commentary:
+
+;; Major mode for the Jade templating language
+;; (https://jade-lang.com/).
+
+;;; Code:
+
 (require 'font-lock)
 (require 'js)
 
@@ -54,6 +65,8 @@
     ;; to next line for convenience
     (comment-or-uncomment-region start end)
     (forward-line)))
+
+;; Inspired by http://xahlee.org/emacs/elisp_syntax_coloring.html
 
 (defconst jade-keywords
   (eval-when-compile

--- a/stylus-mode.el
+++ b/stylus-mode.el
@@ -1,10 +1,19 @@
-;;; stylus-mode.el --- Major mode for editing .jade files
-;;;
-;;; URL: https://github.com/brianc/jade-mode
-;;; Author: Brian M. Carlson and other contributors
-;;; Package-Requires: ((sws-mode "0"))
-;;;
-;;; copied from http://xahlee.org/emacs/elisp_syntax_coloring.html
+;;; slylus-mode.el --- Major mode for editing .styl files  -*- lexical-binding: t -*-
+
+;; Copyright 2011-2021  Brian Carlson
+
+;; Author: Brian M. Carlson and other contributors
+;; Version: 1.0.1
+;; Keywords: languages
+;; URL: https://github.com/brianc/jade-mode
+
+;;; Commentary:
+
+;; Major mode for the Stylus templating language
+;; (https://stylus-lang.com/).
+
+;;; Code:
+
 (require 'font-lock)
 (require 'sws-mode)
 
@@ -24,6 +33,8 @@
 (defun stylus-blank-line-p ()
   "If line contains only spaces."
   (string-match-p "^[ ]*$" (stylus-line-as-string)))
+
+;;; copied from http://xahlee.org/emacs/elisp_syntax_coloring.html
 
 (defconst stylus-colours
   (eval-when-compile

--- a/sws-mode.el
+++ b/sws-mode.el
@@ -1,8 +1,18 @@
-;;; sws-mode.el --- (S)ignificant (W)hite(S)pace mode
-;;;
-;;; URL: https://github.com/brianc/jade-mode
-;;; Author: Brian M. Carlson and other contributors
-;;;
+;;; sws-mode.el --- (S)ignificant (W)hite(S)pace mode  -*- lexical-binding: t -*-
+
+;; Copyright 2011-2021  Brian Carlson
+
+;; Author: Brian M. Carlson and other contributors
+;; Version: 1.0.1
+;; Keywords: languages
+;; URL: https://github.com/brianc/jade-mode
+
+;;; Commentary:
+
+;; Common code for the jade-mode and stylus-mode.
+
+;;; Code:
+
 (require 'font-lock)
 
 (defvar sws-tab-width 2)


### PR DESCRIPTION
Hi,

I am considering adding the packages in this repository to [NonGNU ELPA](https://elpa.nongnu.org/), the new package repository for external code, that will be enabled from Emacs 28 onwards. Compared to MELPA, ELPA requires a more strict adherence to [packaging guidelines](https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html). This patch would fix everything required for including jade-mode and stylus-mode in NonGNU ELPA, as soon as these issues have been resolved.

Along these lines, it would also be nice if  #70 could be merged first, as I think it is a worthwhile fix.