### PR TITLE
Fix small typo

### DIFF
--- a/stylus-mode.el
+++ b/stylus-mode.el
@@ -1,4 +1,4 @@
-;;; slylus-mode.el --- Major mode for editing .styl files  -*- lexical-binding: t -*-
+;;; stylus-mode.el --- Major mode for editing .styl files  -*- lexical-binding: t -*-
 
 ;; Copyright 2011-2021  Brian Carlson
 


### PR DESCRIPTION
This was causing gcc-emacs to fail compilation because it was looking for `;;; slylus-mode.el ends here`.